### PR TITLE
GeoEvent aware output transport and authentification in MQTT

### DIFF
--- a/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttOutboundTransport.java
+++ b/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttOutboundTransport.java
@@ -33,105 +33,78 @@ import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 import com.esri.ges.core.component.ComponentException;
 import com.esri.ges.core.component.RunningException;
 import com.esri.ges.core.component.RunningState;
+import com.esri.ges.core.geoevent.GeoEvent;
 import com.esri.ges.framework.i18n.BundleLogger;
 import com.esri.ges.framework.i18n.BundleLoggerFactory;
+import com.esri.ges.transport.GeoEventAwareTransport;
 import com.esri.ges.transport.OutboundTransportBase;
 import com.esri.ges.transport.TransportDefinition;
 
-public class MqttOutboundTransport extends OutboundTransportBase
-{
+public class MqttOutboundTransport extends OutboundTransportBase implements GeoEventAwareTransport {
 
-	private static final BundleLogger	log	= BundleLoggerFactory.getLogger(MqttOutboundTransport.class);
+	private static final BundleLogger log = BundleLoggerFactory.getLogger(MqttOutboundTransport.class);
 
-	private int												port;
-	private String										host;
-	private String										topic;
-	private MqttClient								mqttClient;
+	private int port;
+	private String host;
+	private String topic;
+	private MqttClient mqttClient;
 
-	public MqttOutboundTransport(TransportDefinition definition) throws ComponentException
-	{
+	public MqttOutboundTransport(TransportDefinition definition) throws ComponentException {
 		super(definition);
 	}
 
 	@Override
-	public void start() throws RunningException
-	{
-		try
-		{
+	public void start() throws RunningException {
+		try {
 			setRunningState(RunningState.STARTING);
 			applyProperties();
 			connectMqtt();
 			setRunningState(RunningState.STARTED);
-		}
-		catch (Exception e)
-		{
+		} catch (Exception e) {
 			log.error("INIT_ERROR", e, this.getClass().getName());
 			setRunningState(RunningState.ERROR);
 		}
 	}
 
 	@Override
-	public void receive(ByteBuffer buffer, String channelId)
-	{
-		try
-		{
-			if (mqttClient == null || !mqttClient.isConnected())
-				connectMqtt();
-
-			byte[] b = new byte[buffer.remaining()];
-			buffer.get(b);
-
-			mqttClient.publish(topic, b, 2, true);
-		}
-		catch (Exception e)
-		{
-			log.error("ERROR_PUBLISHING", e);
-		}
+	public void receive(ByteBuffer buffer, String channelId) {
+		receive(buffer, channelId, null);
 	}
 
-	private void connectMqtt() throws MqttException
-	{
+	private void connectMqtt() throws MqttException {
 		String url = "tcp://" + host + ":" + Integer.toString(port);
 		mqttClient = new MqttClient(url, MqttClient.generateClientId(), new MemoryPersistence());
 		mqttClient.connect();
 	}
 
-	private void applyProperties() throws Exception
-	{
+	private void applyProperties() throws Exception {
 		port = 1883; // default
-		if (getProperty("port").isValid())
-		{
+		if (getProperty("port").isValid()) {
 			int value = (Integer) getProperty("port").getValue();
-			if (value > 0 && value != port)
-			{
+			if (value > 0 && value != port) {
 				port = value;
 			}
 		}
 
 		host = "iot.eclipse.org"; // default
-		if (getProperty("host").isValid())
-		{
+		if (getProperty("host").isValid()) {
 			String value = (String) getProperty("host").getValue();
-			if (!value.trim().equals(""))
-			{
+			if (!value.trim().equals("")) {
 				host = value;
 			}
 		}
 
 		topic = "topic/actuators/light"; // default
-		if (getProperty("topic").isValid())
-		{
+		if (getProperty("topic").isValid()) {
 			String value = (String) getProperty("topic").getValue();
-			if (!value.trim().equals(""))
-			{
+			if (!value.trim().equals("")) {
 				topic = value;
 			}
 		}
 	}
 
 	@Override
-	public synchronized void stop()
-	{
+	public synchronized void stop() {
 		setRunningState(RunningState.STOPPING);
 
 		if (this.mqttClient != null)
@@ -140,27 +113,46 @@ public class MqttOutboundTransport extends OutboundTransportBase
 		setRunningState(RunningState.STOPPED);
 	}
 
-	private void disconnectMqtt()
-	{
-		try
-		{
-			if (mqttClient != null)
-			{
-				if (mqttClient.isConnected())
-				{
+	private void disconnectMqtt() {
+		try {
+			if (mqttClient != null) {
+				if (mqttClient.isConnected()) {
 					mqttClient.disconnect();
 					mqttClient.close();
 				}
 			}
-		}
-		catch (MqttException e)
-		{
+		} catch (MqttException e) {
 			log.error("UNABLE_TO_CLOSE", e);
-		}
-		finally
-		{
+		} finally {
 			mqttClient = null;
 		}
+	}
+
+	/**
+	 * Receives the data of a GeoEvent as raw bytes and in addition the GeoEvent
+	 * to use the value of a GeoEvent field for the topic property.
+	 */
+	@Override
+	public void receive(ByteBuffer buffer, String channelID, GeoEvent geoEvent) {
+		if (geoEvent != null) {
+			String topic = getProperty("topic").getValueAsString();
+			// Get a formatted String with the value of a specified GeoEvent
+			// field for the MQTT topic.
+			this.topic = geoEvent.formatString(topic);
+		}
+
+		try {
+			if (mqttClient == null || !mqttClient.isConnected())
+				connectMqtt();
+
+			byte[] b = new byte[buffer.remaining()];
+			buffer.get(b);
+
+			mqttClient.publish(topic, b, 2, true);
+		} catch (Exception e) {
+			log.error("ERROR_PUBLISHING", e);
+		}
+
 	}
 
 }

--- a/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttOutboundTransport.java
+++ b/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttOutboundTransport.java
@@ -47,7 +47,6 @@ public class MqttOutboundTransport extends OutboundTransportBase implements GeoE
 
 	private int port;
 	private String host;
-	private String topic;
 	private String username;
 	private char[] password;
 	private MqttClient mqttClient;
@@ -88,7 +87,7 @@ public class MqttOutboundTransport extends OutboundTransportBase implements GeoE
 			options.setPassword(password);
 
 			mqttClient.connect(options);
-		} 
+		}
 		// Otherwise connect without username and password.
 		else {
 			mqttClient.connect();
@@ -112,21 +111,15 @@ public class MqttOutboundTransport extends OutboundTransportBase implements GeoE
 			}
 		}
 
-		topic = "topic/actuators/light"; // default
-		if (getProperty("topic").isValid()) {
-			String value = (String) getProperty("topic").getValue();
-			if (!value.trim().equals("")) {
-				topic = value;
-			}
-		}
 		
-		//Get the username as a simple String.
+
+		// Get the username as a simple String.
 		if (getProperty("username").isValid()) {
 			String value = (String) getProperty("username").getValue();
 			username = value.trim();
 		}
 
-		//Get the password as a DecryptedValue an convert it to an Char array.
+		// Get the password as a DecryptedValue an convert it to an Char array.
 		if (getProperty("password").isValid()) {
 			String value = (String) getProperty("password").getDecryptedValue();
 			password = value.toCharArray();
@@ -164,11 +157,19 @@ public class MqttOutboundTransport extends OutboundTransportBase implements GeoE
 	 */
 	@Override
 	public void receive(ByteBuffer buffer, String channelID, GeoEvent geoEvent) {
+		
+		String topic = "topic/actuators/light"; // default
+		if (getProperty("topic").isValid()) {
+			String value = (String) getProperty("topic").getValue();
+			if (!value.trim().equals("")) {
+				topic = value;
+			}
+		}
+
 		if (geoEvent != null) {
-			String topic = getProperty("topic").getValueAsString();
 			// Get a formatted String with the value of a specified GeoEvent
 			// field for the MQTT topic.
-			this.topic = geoEvent.formatString(topic);
+			topic = geoEvent.formatString(topic);
 		}
 
 		try {

--- a/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttOutboundTransport.java
+++ b/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttOutboundTransport.java
@@ -47,6 +47,7 @@ public class MqttOutboundTransport extends OutboundTransportBase implements GeoE
 
 	private int port;
 	private String host;
+	private String topic;
 	private String username;
 	private char[] password;
 	private MqttClient mqttClient;
@@ -111,7 +112,13 @@ public class MqttOutboundTransport extends OutboundTransportBase implements GeoE
 			}
 		}
 
-		
+		topic = "topic/actuators/light"; // default
+		if (getProperty("topic").isValid()) {
+			String value = (String) getProperty("topic").getValue();
+			if (!value.trim().equals("")) {
+				topic = value;
+			}
+		}
 
 		// Get the username as a simple String.
 		if (getProperty("username").isValid()) {
@@ -157,16 +164,10 @@ public class MqttOutboundTransport extends OutboundTransportBase implements GeoE
 	 */
 	@Override
 	public void receive(ByteBuffer buffer, String channelID, GeoEvent geoEvent) {
-		
-		String topic = "topic/actuators/light"; // default
-		if (getProperty("topic").isValid()) {
-			String value = (String) getProperty("topic").getValue();
-			if (!value.trim().equals("")) {
-				topic = value;
-			}
-		}
 
-		if (geoEvent != null) {
+		String topic = this.topic;
+
+		if (geoEvent != null && topic.contains("$")) {
 			// Get a formatted String with the value of a specified GeoEvent
 			// field for the MQTT topic.
 			topic = geoEvent.formatString(topic);

--- a/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport.properties
+++ b/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport.properties
@@ -7,6 +7,10 @@ TRANSPORT_IN_PORT_LBL=Port
 TRANSPORT_IN_PORT_DESC=Port of the TCP connection to the MQTT broker.
 TRANSPORT_IN_TOPIC_LBL=Topic
 TRANSPORT_IN_TOPIC_DESC=Topic of the connection to the MQTT broker.
+TRANSPORT_IN_USERNAME_LBL=User name
+TRANSPORT_IN_USERNAME_DESC=Name of the user for the connection to the MQTT broker.
+TRANSPORT_IN_PASSWORD_LBL=Password
+TRANSPORT_IN_PASSWORD_DESC=Password for the connection to the MQTT broker.
 
 # Outbound Transport Definition
 TRANSPORT_OUT_LBL=MQTT Outbound Transport
@@ -17,6 +21,10 @@ TRANSPORT_OUT_PORT_LBL=Port
 TRANSPORT_OUT_PORT_DESC=Port of the TCP connection to the MQTT broker.
 TRANSPORT_OUT_TOPIC_LBL=Topic
 TRANSPORT_OUT_TOPIC_DESC=Topic of the connection to the MQTT broker.
+TRANSPORT_OUT_USERNAME_LBL=User name
+TRANSPORT_OUT_USERNAME_DESC=Name of the user for the connection to the MQTT broker.
+TRANSPORT_OUT_PASSWORD_LBL=Password
+TRANSPORT_OUT_PASSWORD_DESC=Password for the connection to the MQTT broker.
 
 # Log Messages
 CONNECTION_LOST=Connection lost: {0}

--- a/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport_en_US.properties
+++ b/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport_en_US.properties
@@ -7,6 +7,10 @@ TRANSPORT_IN_PORT_LBL=Port
 TRANSPORT_IN_PORT_DESC=Port of the TCP connection to the MQTT broker.
 TRANSPORT_IN_TOPIC_LBL=Topic
 TRANSPORT_IN_TOPIC_DESC=Topic of the connection to the MQTT broker.
+TRANSPORT_IN_USERNAME_LBL=User name
+TRANSPORT_IN_USERNAME_DESC=Name of the user for the connection to the MQTT broker.
+TRANSPORT_IN_PASSWORD_LBL=Password
+TRANSPORT_IN_PASSWORD_DESC=Password for the connection to the MQTT broker.
 
 # Outbound Transport Definition
 TRANSPORT_OUT_LBL=MQTT Outbound Transport
@@ -17,6 +21,10 @@ TRANSPORT_OUT_PORT_LBL=Port
 TRANSPORT_OUT_PORT_DESC=Port of the TCP connection to the MQTT broker.
 TRANSPORT_OUT_TOPIC_LBL=Topic
 TRANSPORT_OUT_TOPIC_DESC=Topic of the connection to the MQTT broker.
+TRANSPORT_OUT_USERNAME_LBL=User name
+TRANSPORT_OUT_USERNAME_DESC=Name of the user for the connection to the MQTT broker.
+TRANSPORT_OUT_PASSWORD_LBL=Password
+TRANSPORT_OUT_PASSWORD_DESC=Password for the connection to the MQTT broker.
 
 # Log Messages
 CONNECTION_LOST=Connection lost: {0}

--- a/mqtt-transport/src/main/resources/mqtt-inbound-transport-definition.xml
+++ b/mqtt-transport/src/main/resources/mqtt-inbound-transport-definition.xml
@@ -1,6 +1,6 @@
 <transport name="MqttInboundTransport"
 	label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_LBL}"
-	contact="yourname@yourcompany.com" version="10.4.0"
+	contact="sebastian.drost@hs-bochum.de" version="10.4.0"
 	domain="com.esri.geoevent.transport.mqtt.inbound" type="inbound">
 	<description>${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_DESC}
 	</description>
@@ -18,6 +18,16 @@
 			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_TOPIC_LBL}"
 			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_TOPIC_DESC}"
 			propertyType="String" defaultValue="SBC/test" mandatory="true"
+			readOnly="false" />
+			<propertyDefinition propertyName="username"
+			label="${com.esri.geoevent.transport.mqtt-extended-transport.TRANSPORT_IN_USERNAME_LBL}"
+			description="${com.esri.geoevent.transport.mqtt-extended-transport.TRANSPORT_IN_USERNAME_DESC}"
+			propertyType="String" defaultValue="" mandatory="false"
+			readOnly="false" />
+		<propertyDefinition propertyName="password"
+			label="${com.esri.geoevent.transport.mqtt-extended-transport.TRANSPORT_IN_PASSWORD_LBL}"
+			description="${com.esri.geoevent.transport.mqtt-extended-transport.TRANSPORT_IN_PASSWORD_DESC}"
+			propertyType="Password" defaultValue="" mandatory="false"
 			readOnly="false" />
 	</propertyDefinitions>
 </transport>

--- a/mqtt-transport/src/main/resources/mqtt-inbound-transport-definition.xml
+++ b/mqtt-transport/src/main/resources/mqtt-inbound-transport-definition.xml
@@ -1,6 +1,6 @@
 <transport name="MqttInboundTransport"
 	label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_LBL}"
-	contact="sebastian.drost@hs-bochum.de" version="10.4.0"
+	contact="yourname@yourcompany.com" version="10.4.0"
 	domain="com.esri.geoevent.transport.mqtt.inbound" type="inbound">
 	<description>${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_DESC}
 	</description>

--- a/mqtt-transport/src/main/resources/mqtt-outbound-transport-definition.xml
+++ b/mqtt-transport/src/main/resources/mqtt-outbound-transport-definition.xml
@@ -1,7 +1,7 @@
 <transport name="MqttOutboundTransport"
-	label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_LBL}" contact="yourname@yourcompany.com"
-	version="10.4.0" domain="com.esri.geoevent.transport.mqtt.outbound"
-	type="outbound">
+	label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_LBL}"
+	contact="sebastian.drost@hs-bochum.de" version="10.4.0"
+	domain="com.esri.geoevent.transport.mqtt.outbound" type="outbound">
 	<description>${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_DESC}
 	</description>
 	<propertyDefinitions>
@@ -19,5 +19,13 @@
 			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_TOPIC_DESC}"
 			propertyType="String" defaultValue="SBC/test" mandatory="true"
 			readOnly="false" />
+		<propertyDefinition propertyName="username"
+			label="${com.esri.geoevent.transport.mqtt-extended-transport.TRANSPORT_OUT_USERNAME_LBL}"
+			description="${com.esri.geoevent.transport.mqtt-extended-transport.TRANSPORT_OUT_USERNAME_DESC}"
+			propertyType="String" defaultValue="" mandatory="false" readOnly="false" />
+		<propertyDefinition propertyName="password"
+			label="${com.esri.geoevent.transport.mqtt-extended-transport.TRANSPORT_OUT_PASSWORD_LBL}"
+			description="${com.esri.geoevent.transport.mqtt-extended-transport.TRANSPORT_OUT_PASSWORD_DESC}"
+			propertyType="Password" defaultValue="" mandatory="false" readOnly="false" />
 	</propertyDefinitions>
 </transport>

--- a/mqtt-transport/src/main/resources/mqtt-outbound-transport-definition.xml
+++ b/mqtt-transport/src/main/resources/mqtt-outbound-transport-definition.xml
@@ -1,6 +1,6 @@
 <transport name="MqttOutboundTransport"
 	label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_LBL}"
-	contact="sebastian.drost@hs-bochum.de" version="10.4.0"
+	contact="yourname@yourcompany.com" version="10.4.0"
 	domain="com.esri.geoevent.transport.mqtt.outbound" type="outbound">
 	<description>${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_DESC}
 	</description>


### PR DESCRIPTION
Extended the output transport to a GeoEvent aware output transport. Now you can use a GeoEvent field value for the MQTT topic property. This property can be specified in the topic property field when creating a output connector in the GeoEvent Manager.

Also extended the input and output transport with the capabiltiy to connect to a MQTT broker with a username and a password. This can be used for authentification in MQTT. The values can be specified when creating a new input or output connector in seperate property fields.
