### PR TITLE
Cleaned up username / password support from SebaDro

### DIFF
--- a/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttInboundTransport.java
+++ b/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttInboundTransport.java
@@ -30,6 +30,7 @@ import java.nio.ByteBuffer;
 import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
 import org.eclipse.paho.client.mqttv3.MqttCallback;
 import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
@@ -52,6 +53,8 @@ public class MqttInboundTransport extends InboundTransportBase implements Runnab
 	private String										host;
 	private String										topic;
 	private MqttClient								mqttClient;
+	private String										username;
+	private char[]										password;
 
 	public MqttInboundTransport(TransportDefinition definition) throws ComponentException
 	{
@@ -125,7 +128,18 @@ public class MqttInboundTransport extends InboundTransportBase implements Runnab
 						log.error("CONNECTION_LOST", cause.getLocalizedMessage());
 					}
 				});
-			mqttClient.connect();
+
+			MqttConnectOptions options = new MqttConnectOptions();
+
+			// Connect with username and password if both are available.
+			if (!username.equals("") && password.length > 0)
+			{
+				options.setUserName(username);
+				options.setPassword(password);
+			}
+            
+			options.setCleanSession(true);
+			mqttClient.connect(options);
 			mqttClient.subscribe(topic, 1);
 
 		}
@@ -197,6 +211,19 @@ public class MqttInboundTransport extends InboundTransportBase implements Runnab
 			{
 				topic = value;
 			}
+		}
+		//Get the username as a simple String.
+		if (getProperty("username").isValid())
+		{
+			String value = (String) getProperty("username").getValue();
+			username = value.trim(); 
+		}
+
+		//Get the password as a DecryptedValue an convert it to an Char array.
+		if (getProperty("password").isValid())
+		{
+			String value = (String) getProperty("password").getDecryptedValue();
+			password = value.toCharArray();
 		}
 	}
 

--- a/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttOutboundTransport.java
+++ b/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttOutboundTransport.java
@@ -27,6 +27,7 @@ package com.esri.geoevent.transport.mqtt;
 import java.nio.ByteBuffer;
 
 import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 
@@ -47,6 +48,8 @@ public class MqttOutboundTransport extends OutboundTransportBase
 	private String										host;
 	private String										topic;
 	private MqttClient								mqttClient;
+	private String										username;
+	private char[]										password;
 
 	public MqttOutboundTransport(TransportDefinition definition) throws ComponentException
 	{
@@ -93,7 +96,18 @@ public class MqttOutboundTransport extends OutboundTransportBase
 	{
 		String url = "tcp://" + host + ":" + Integer.toString(port);
 		mqttClient = new MqttClient(url, MqttClient.generateClientId(), new MemoryPersistence());
-		mqttClient.connect();
+
+		MqttConnectOptions options = new MqttConnectOptions();
+
+		// Connect with username and password if both are available.
+		if (!username.equals("") && password.length > 0)
+		{
+			options.setUserName(username);
+			options.setPassword(password);
+		}
+
+		options.setCleanSession(true);
+		mqttClient.connect(options);
 	}
 
 	private void applyProperties() throws Exception
@@ -126,6 +140,20 @@ public class MqttOutboundTransport extends OutboundTransportBase
 			{
 				topic = value;
 			}
+		}
+		
+		//Get the username as a simple String.
+		if (getProperty("username").isValid())
+		{
+			String value = (String) getProperty("username").getValue();
+			username = value.trim();
+		}
+
+		//Get the password as a DecryptedValue an convert it to an Char array.
+		if (getProperty("password").isValid())
+		{
+			String value = (String) getProperty("password").getDecryptedValue();
+			password = value.toCharArray();
 		}
 	}
 

--- a/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport.properties
+++ b/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport.properties
@@ -7,16 +7,24 @@ TRANSPORT_IN_PORT_LBL=Port
 TRANSPORT_IN_PORT_DESC=Port of the TCP connection to the MQTT broker.
 TRANSPORT_IN_TOPIC_LBL=Topic
 TRANSPORT_IN_TOPIC_DESC=Topic of the connection to the MQTT broker.
+TRANSPORT_IN_USERNAME_LBL=User name
+TRANSPORT_IN_USERNAME_DESC=Name of the user for the connection to the MQTT broker.
+TRANSPORT_IN_PASSWORD_LBL=Password
+TRANSPORT_IN_PASSWORD_DESC=Password for the connection to the MQTT broker.
 
 # Outbound Transport Definition
 TRANSPORT_OUT_LBL=MQTT Outbound Transport
-TRANSPORT_OUT_DESC=This is an MQTT outbound transport.b
+TRANSPORT_OUT_DESC=This is an MQTT outbound transport.
 TRANSPORT_OUT_HOST_LBL=Host
 TRANSPORT_OUT_HOST_DESC=Host URL of the TCP connection to the MQTT broker.
 TRANSPORT_OUT_PORT_LBL=Port
 TRANSPORT_OUT_PORT_DESC=Port of the TCP connection to the MQTT broker.
 TRANSPORT_OUT_TOPIC_LBL=Topic
 TRANSPORT_OUT_TOPIC_DESC=Topic of the connection to the MQTT broker.
+TRANSPORT_OUT_USERNAME_LBL=User name
+TRANSPORT_OUT_USERNAME_DESC=Name of the user for the connection to the MQTT broker.
+TRANSPORT_OUT_PASSWORD_LBL=Password
+TRANSPORT_OUT_PASSWORD_DESC=Password for the connection to the MQTT broker.
 
 # Log Messages
 CONNECTION_LOST=Connection lost: {0}

--- a/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport_en_US.properties
+++ b/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport_en_US.properties
@@ -7,16 +7,24 @@ TRANSPORT_IN_PORT_LBL=Port
 TRANSPORT_IN_PORT_DESC=Port of the TCP connection to the MQTT broker.
 TRANSPORT_IN_TOPIC_LBL=Topic
 TRANSPORT_IN_TOPIC_DESC=Topic of the connection to the MQTT broker.
+TRANSPORT_IN_USERNAME_LBL=User name
+TRANSPORT_IN_USERNAME_DESC=Name of the user for the connection to the MQTT broker.
+TRANSPORT_IN_PASSWORD_LBL=Password
+TRANSPORT_IN_PASSWORD_DESC=Password for the connection to the MQTT broker.
 
 # Outbound Transport Definition
 TRANSPORT_OUT_LBL=MQTT Outbound Transport
-TRANSPORT_OUT_DESC=This is an MQTT outbound transport.b
+TRANSPORT_OUT_DESC=This is an MQTT outbound transport.
 TRANSPORT_OUT_HOST_LBL=Host
 TRANSPORT_OUT_HOST_DESC=Host URL of the TCP connection to the MQTT broker.
 TRANSPORT_OUT_PORT_LBL=Port
 TRANSPORT_OUT_PORT_DESC=Port of the TCP connection to the MQTT broker.
 TRANSPORT_OUT_TOPIC_LBL=Topic
 TRANSPORT_OUT_TOPIC_DESC=Topic of the connection to the MQTT broker.
+TRANSPORT_OUT_USERNAME_LBL=User name
+TRANSPORT_OUT_USERNAME_DESC=Name of the user for the connection to the MQTT broker.
+TRANSPORT_OUT_PASSWORD_LBL=Password
+TRANSPORT_OUT_PASSWORD_DESC=Password for the connection to the MQTT broker.
 
 # Log Messages
 CONNECTION_LOST=Connection lost: {0}

--- a/mqtt-transport/src/main/resources/mqtt-inbound-transport-definition.xml
+++ b/mqtt-transport/src/main/resources/mqtt-inbound-transport-definition.xml
@@ -19,5 +19,15 @@
 			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_TOPIC_DESC}"
 			propertyType="String" defaultValue="SBC/test" mandatory="true"
 			readOnly="false" />
+			<propertyDefinition propertyName="username"
+			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_USERNAME_LBL}"
+			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_USERNAME_DESC}"
+			propertyType="String" defaultValue="" mandatory="false"
+			readOnly="false" />
+		<propertyDefinition propertyName="password"
+			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_PASSWORD_LBL}"
+			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_PASSWORD_DESC}"
+			propertyType="Password" defaultValue="" mandatory="false"
+			readOnly="false" />
 	</propertyDefinitions>
 </transport>

--- a/mqtt-transport/src/main/resources/mqtt-outbound-transport-definition.xml
+++ b/mqtt-transport/src/main/resources/mqtt-outbound-transport-definition.xml
@@ -19,5 +19,13 @@
 			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_TOPIC_DESC}"
 			propertyType="String" defaultValue="SBC/test" mandatory="true"
 			readOnly="false" />
+		<propertyDefinition propertyName="username"
+			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_USERNAME_LBL}"
+			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_USERNAME_DESC}"
+			propertyType="String" defaultValue="" mandatory="false" readOnly="false" />
+		<propertyDefinition propertyName="password"
+			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_PASSWORD_LBL}"
+			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_PASSWORD_DESC}"
+			propertyType="Password" defaultValue="" mandatory="false" readOnly="false" />
 	</propertyDefinitions>
 </transport>


### PR DESCRIPTION
Extracted the username / password support from the changes proposed by @SebaDro, reformatted to match original indentation / whitespace from upstream master and cleaned up some typos. Also, apply options.setCleanSession(true) even if no username / password are provided.

_This does not include the GeoEvent aware topic support also included in @SebaDro's original pull request, although I do think that change is interesting and may be worth consideration separately._