### PR TITLE
Add configurable properties for qos and retain

### DIFF
--- a/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttInboundTransport.java
+++ b/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttInboundTransport.java
@@ -51,6 +51,7 @@ public class MqttInboundTransport extends InboundTransportBase implements Runnab
 	private int												port;
 	private String										host;
 	private String										topic;
+	private int												qos;
 	private MqttClient								mqttClient;
 
 	public MqttInboundTransport(TransportDefinition definition) throws ComponentException
@@ -126,7 +127,7 @@ public class MqttInboundTransport extends InboundTransportBase implements Runnab
 					}
 				});
 			mqttClient.connect();
-			mqttClient.subscribe(topic, 1);
+			mqttClient.subscribe(topic, qos);
 
 		}
 		catch (Throwable ex)
@@ -196,6 +197,21 @@ public class MqttInboundTransport extends InboundTransportBase implements Runnab
 			if (!value.trim().equals(""))
 			{
 				topic = value;
+			}
+		}
+
+		qos = 0;
+		if (getProperty("qos").isValid()) {
+			try
+			{
+				int value = Integer.parseInt(getProperty("qos").getValueAsString());
+				if ((value >= 0) && (value <= 2)) {
+					qos = value;
+				}
+			}
+			catch (NumberFormatException e)
+			{
+				throw e; // shouldn't ever happen
 			}
 		}
 	}

--- a/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttOutboundTransport.java
+++ b/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttOutboundTransport.java
@@ -46,6 +46,8 @@ public class MqttOutboundTransport extends OutboundTransportBase
 	private int												port;
 	private String										host;
 	private String										topic;
+	private int												qos;
+	private boolean										retain;
 	private MqttClient								mqttClient;
 
 	public MqttOutboundTransport(TransportDefinition definition) throws ComponentException
@@ -81,7 +83,7 @@ public class MqttOutboundTransport extends OutboundTransportBase
 			byte[] b = new byte[buffer.remaining()];
 			buffer.get(b);
 
-			mqttClient.publish(topic, b, 2, true);
+			mqttClient.publish(topic, b, qos, retain);
 		}
 		catch (Exception e)
 		{
@@ -126,6 +128,29 @@ public class MqttOutboundTransport extends OutboundTransportBase
 			{
 				topic = value;
 			}
+		}
+
+		qos = 0;
+		if (getProperty("qos").isValid())
+		{
+			try
+			{
+				int value = Integer.parseInt(getProperty("qos").getValueAsString());
+				if ((value >= 0) && (value <= 2))
+				{
+					qos = value;
+				}
+			}
+			catch (NumberFormatException e)
+			{
+				throw e; // shouldn't ever happen but needed to be string for pick list
+			}
+		}
+
+		retain = false;
+		if (getProperty("retain").isValid())
+		{
+			retain = ((Boolean)getProperty("retain").getValue()).booleanValue();
 		}
 	}
 

--- a/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport.properties
+++ b/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport.properties
@@ -24,6 +24,11 @@ TRANSPORT_OUT_RETAIN_MESSAGE_DESC=Instruct broker to retain last message sent on
 TRANSPORT_OUT_TOPIC_LBL=Topic
 TRANSPORT_OUT_TOPIC_DESC=Topic of the connection to the MQTT broker.
 
+# Transport QOS option labels
+TRANSPORT_COMMON_QOS_0_LBL=0 (at most once)
+TRANSPORT_COMMON_QOS_1_LBL=1 (at least once)
+TRANSPORT_COMMON_QOS_2_LBL=2 (exactly once)
+
 # Log Messages
 CONNECTION_LOST=Connection lost: {0}
 UNEXPECTED_ERROR=Unexpected error during MQTT receiver initialization.

--- a/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport.properties
+++ b/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport.properties
@@ -5,6 +5,8 @@ TRANSPORT_IN_HOST_LBL=Host
 TRANSPORT_IN_HOST_DESC=Host URL of the TCP connection to the MQTT broker.
 TRANSPORT_IN_PORT_LBL=Port
 TRANSPORT_IN_PORT_DESC=Port of the TCP connection to the MQTT broker.
+TRANSPORT_IN_QOS_LBL=QOS Level
+TRANSPORT_IN_QOS_DESC=Quality of Service level requested for subscription (0=at most once, 1=at least once, 2=exactly once)
 TRANSPORT_IN_TOPIC_LBL=Topic
 TRANSPORT_IN_TOPIC_DESC=Topic of the connection to the MQTT broker.
 
@@ -15,6 +17,10 @@ TRANSPORT_OUT_HOST_LBL=Host
 TRANSPORT_OUT_HOST_DESC=Host URL of the TCP connection to the MQTT broker.
 TRANSPORT_OUT_PORT_LBL=Port
 TRANSPORT_OUT_PORT_DESC=Port of the TCP connection to the MQTT broker.
+TRANSPORT_OUT_QOS_LBL=QOS Level
+TRANSPORT_OUT_QOS_DESC=Quality of Service level specified for delivery (0=at most once, 1=at least once, 2=exactly once)
+TRANSPORT_OUT_RETAIN_MESSAGE_LBL=Retain message
+TRANSPORT_OUT_RETAIN_MESSAGE_DESC=Instruct broker to retain last message sent on each distinct topic
 TRANSPORT_OUT_TOPIC_LBL=Topic
 TRANSPORT_OUT_TOPIC_DESC=Topic of the connection to the MQTT broker.
 

--- a/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport_en_US.properties
+++ b/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport_en_US.properties
@@ -24,6 +24,11 @@ TRANSPORT_OUT_RETAIN_MESSAGE_DESC=Instruct broker to retain last message sent on
 TRANSPORT_OUT_TOPIC_LBL=Topic
 TRANSPORT_OUT_TOPIC_DESC=Topic of the connection to the MQTT broker.
 
+# Transport QOS option labels
+TRANSPORT_COMMON_QOS_0_LBL=0 (at most once)
+TRANSPORT_COMMON_QOS_1_LBL=1 (at least once)
+TRANSPORT_COMMON_QOS_2_LBL=2 (exactly once)
+
 # Log Messages
 CONNECTION_LOST=Connection lost: {0}
 UNEXPECTED_ERROR=Unexpected error during MQTT receiver initialization.

--- a/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport_en_US.properties
+++ b/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport_en_US.properties
@@ -5,6 +5,8 @@ TRANSPORT_IN_HOST_LBL=Host
 TRANSPORT_IN_HOST_DESC=Host URL of the TCP connection to the MQTT broker.
 TRANSPORT_IN_PORT_LBL=Port
 TRANSPORT_IN_PORT_DESC=Port of the TCP connection to the MQTT broker.
+TRANSPORT_IN_QOS_LBL=QOS Level
+TRANSPORT_IN_QOS_DESC=Quality of Service level requested for subscription (0=at most once, 1=at least once, 2=exactly once)
 TRANSPORT_IN_TOPIC_LBL=Topic
 TRANSPORT_IN_TOPIC_DESC=Topic of the connection to the MQTT broker.
 
@@ -15,6 +17,10 @@ TRANSPORT_OUT_HOST_LBL=Host
 TRANSPORT_OUT_HOST_DESC=Host URL of the TCP connection to the MQTT broker.
 TRANSPORT_OUT_PORT_LBL=Port
 TRANSPORT_OUT_PORT_DESC=Port of the TCP connection to the MQTT broker.
+TRANSPORT_OUT_QOS_LBL=QOS Level
+TRANSPORT_OUT_QOS_DESC=Quality of Service level specified for delivery (0=at most once, 1=at least once, 2=exactly once)
+TRANSPORT_OUT_RETAIN_MESSAGE_LBL=Retain message
+TRANSPORT_OUT_RETAIN_MESSAGE_DESC=Instruct broker to retain last message sent on each distinct topic
 TRANSPORT_OUT_TOPIC_LBL=Topic
 TRANSPORT_OUT_TOPIC_DESC=Topic of the connection to the MQTT broker.
 

--- a/mqtt-transport/src/main/resources/mqtt-inbound-transport-definition.xml
+++ b/mqtt-transport/src/main/resources/mqtt-inbound-transport-definition.xml
@@ -20,9 +20,9 @@
 			propertyType="String" defaultValue="0" mandatory="true"
 			readOnly="false">
 			<allowedValues>
-				<value label="0 (at most once)">0</value>
-				<value label="1 (at least once)">1</value>
-				<value label="2 (exactly once)">2</value>
+				<value label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_COMMON_QOS_0_LBL}">0</value>
+				<value label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_COMMON_QOS_1_LBL}">1</value>
+				<value label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_COMMON_QOS_2_LBL}">2</value>
 			</allowedValues>
 		</propertyDefinition>
 		<propertyDefinition propertyName="topic"

--- a/mqtt-transport/src/main/resources/mqtt-inbound-transport-definition.xml
+++ b/mqtt-transport/src/main/resources/mqtt-inbound-transport-definition.xml
@@ -14,6 +14,17 @@
 			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_PORT_LBL}"
 			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_PORT_DESC}"
 			propertyType="Integer" defaultValue="1883" mandatory="true" readOnly="false" />
+		<propertyDefinition propertyName="qos"
+			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_QOS_LBL}"
+			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_QOS_DESC}"
+			propertyType="String" defaultValue="0" mandatory="true"
+			readOnly="false">
+			<allowedValues>
+				<value label="0 (at most once)">0</value>
+				<value label="1 (at least once)">1</value>
+				<value label="2 (exactly once)">2</value>
+			</allowedValues>
+		</propertyDefinition>
 		<propertyDefinition propertyName="topic"
 			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_TOPIC_LBL}"
 			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_TOPIC_DESC}"

--- a/mqtt-transport/src/main/resources/mqtt-outbound-transport-definition.xml
+++ b/mqtt-transport/src/main/resources/mqtt-outbound-transport-definition.xml
@@ -14,6 +14,22 @@
 			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_PORT_LBL}"
 			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_PORT_DESC}"
 			propertyType="Integer" defaultValue="1883" mandatory="true" readOnly="false" />
+		<propertyDefinition propertyName="qos"
+			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_QOS_LBL}"
+			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_QOS_DESC}"
+			propertyType="String" defaultValue="0" mandatory="true"
+			readOnly="false">
+			<allowedValues>
+				<value label="0 (at most once)">0</value>
+				<value label="1 (at least once)">1</value>
+				<value label="2 (exactly once)">2</value>
+			</allowedValues>
+		</propertyDefinition>
+		<propertyDefinition propertyName="retain"
+			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_RETAIN_LBL}"
+			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_RETAIN_DESC}"
+			propertyType="Boolean" defaultValue="false" mandatory="true"
+			readOnly="false" />
 		<propertyDefinition propertyName="topic"
 			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_TOPIC_LBL}"
 			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_TOPIC_DESC}"

--- a/mqtt-transport/src/main/resources/mqtt-outbound-transport-definition.xml
+++ b/mqtt-transport/src/main/resources/mqtt-outbound-transport-definition.xml
@@ -20,9 +20,9 @@
 			propertyType="String" defaultValue="0" mandatory="true"
 			readOnly="false">
 			<allowedValues>
-				<value label="0 (at most once)">0</value>
-				<value label="1 (at least once)">1</value>
-				<value label="2 (exactly once)">2</value>
+				<value label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_COMMON_QOS_0_LBL}">0</value>
+				<value label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_COMMON_QOS_1_LBL}">1</value>
+				<value label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_COMMON_QOS_2_LBL}">2</value>
 			</allowedValues>
 		</propertyDefinition>
 		<propertyDefinition propertyName="retain"


### PR DESCRIPTION
Add properties for QOS on inbound and outbound, and Retain Message on outbound, rather than hardcoding these arbitrarily as QOS=1 for inbound / 2 for outbound, and Retain=true. The default values are now set to QOS=0 and Retain=false.