### PR TITLE
Add optional scheme and port in Host property, enabling support for SSL encrypted brokers

### DIFF
--- a/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttInboundTransport.java
+++ b/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttInboundTransport.java
@@ -143,6 +143,7 @@ public class MqttInboundTransport extends InboundTransportBase implements Runnab
 				options.setPassword(password);
 			}
 
+			if (ssl)
 			{
 				// Support TLS only (1.0-1.2) as even SSL 3.0 has well known exploits
 				java.util.Properties sslProperties = new java.util.Properties();

--- a/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttInboundTransport.java
+++ b/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttInboundTransport.java
@@ -27,6 +27,10 @@ package com.esri.geoevent.transport.mqtt;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 
+import java.net.MalformedURLException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
 import org.eclipse.paho.client.mqttv3.MqttCallback;
 import org.eclipse.paho.client.mqttv3.MqttClient;
@@ -50,6 +54,7 @@ public class MqttInboundTransport extends InboundTransportBase implements Runnab
 	private Thread										thread	= null;
 	private int												port;
 	private String										host;
+	private boolean										ssl;
 	private String										topic;
 	private MqttClient								mqttClient;
 
@@ -94,7 +99,7 @@ public class MqttInboundTransport extends InboundTransportBase implements Runnab
 			applyProperties();
 			setRunningState(RunningState.STARTED);
 
-			String url = "tcp://" + host + ":" + Integer.toString(port);
+			String url = (ssl ? "ssl://" : "tcp://") + host + ":" + Integer.toString(port);
 			mqttClient = new MqttClient(url, MqttClient.generateClientId(), new MemoryPersistence());
 
 			mqttClient.setCallback(new MqttCallback()
@@ -169,23 +174,26 @@ public class MqttInboundTransport extends InboundTransportBase implements Runnab
 
 	private void applyProperties() throws Exception
 	{
-		port = 1883; // default
-		if (getProperty("port").isValid())
-		{
-			int value = (Integer) getProperty("port").getValue();
-			if (value > 0 && value != port)
-			{
-				port = value;
-			}
-		}
-
+		ssl = false;
+		port = 1883;
 		host = "iot.eclipse.org"; // default
 		if (getProperty("host").isValid())
 		{
 			String value = (String) getProperty("host").getValue();
 			if (!value.trim().equals(""))
 			{
-				host = value;
+				Matcher matcher = Pattern.compile("^(?:(tcp|ssl)://)?([-.a-z0-9]+)(?::([0-9]+))?$", Pattern.CASE_INSENSITIVE).matcher(value);
+				if (matcher.matches())
+				{
+					ssl = "ssl".equalsIgnoreCase(matcher.group(1));
+					host = matcher.group(2);
+					port = matcher.start(3) > -1 ? Integer.parseInt(matcher.group(3)) :
+									ssl ? 8883 : 1883; 
+				}
+				else
+				{
+					throw new MalformedURLException("Invalid MQTT Host URL");
+				}
 			}
 		}
 

--- a/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttInboundTransport.java
+++ b/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttInboundTransport.java
@@ -137,12 +137,19 @@ public class MqttInboundTransport extends InboundTransportBase implements Runnab
 			MqttConnectOptions options = new MqttConnectOptions();
 
 			// Connect with username and password if both are available.
-			if (!username.equals("") && password.length > 0)
+			if (username != null && password != null && !username.isEmpty() && password.length > 0)
 			{
 				options.setUserName(username);
 				options.setPassword(password);
 			}
-            
+
+			{
+				// Support TLS only (1.0-1.2) as even SSL 3.0 has well known exploits
+				java.util.Properties sslProperties = new java.util.Properties();
+				sslProperties.setProperty("com.ibm.ssl.protocol", "TLS");
+				options.setSSLProperties(sslProperties);
+			}
+
 			options.setCleanSession(true);
 			mqttClient.connect(options);
 			mqttClient.subscribe(topic, 1);
@@ -220,18 +227,27 @@ public class MqttInboundTransport extends InboundTransportBase implements Runnab
 				topic = value;
 			}
 		}
+
 		//Get the username as a simple String.
+		username = null;
 		if (getProperty("username").isValid())
 		{
 			String value = (String) getProperty("username").getValue();
-			username = value.trim(); 
+			if (value != null)
+			{
+				username = value.trim();
+			}
 		}
 
 		//Get the password as a DecryptedValue an convert it to an Char array.
+		password = null;
 		if (getProperty("password").isValid())
 		{
 			String value = (String) getProperty("password").getDecryptedValue();
-			password = value.toCharArray();
+			if (value != null)
+			{
+				password = value.toCharArray();
+			}
 		}
 	}
 

--- a/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttOutboundTransport.java
+++ b/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttOutboundTransport.java
@@ -123,10 +123,17 @@ public class MqttOutboundTransport extends OutboundTransportBase implements GeoE
 		MqttConnectOptions options = new MqttConnectOptions();
 
 		// Connect with username and password if both are available.
-		if (!username.equals("") && password.length > 0)
+		if (username != null && password != null && !username.isEmpty() && password.length > 0)
 		{
 			options.setUserName(username);
 			options.setPassword(password);
+		}
+
+		{
+			// Support TLS only (1.0-1.2) as even SSL 3.0 has well known exploits
+			java.util.Properties sslProperties = new java.util.Properties();
+			sslProperties.setProperty("com.ibm.ssl.protocol", "TLS");
+			options.setSSLProperties(sslProperties);
 		}
 
 		options.setCleanSession(true);
@@ -169,17 +176,25 @@ public class MqttOutboundTransport extends OutboundTransportBase implements GeoE
 		}
 		
 		//Get the username as a simple String.
+		username = null;
 		if (getProperty("username").isValid())
 		{
 			String value = (String) getProperty("username").getValue();
-			username = value.trim();
+			if (value != null)
+			{
+				username = value.trim();
+			}
 		}
 
 		//Get the password as a DecryptedValue an convert it to an Char array.
+		password = null;
 		if (getProperty("password").isValid())
 		{
 			String value = (String) getProperty("password").getDecryptedValue();
-			password = value.toCharArray();
+			if (value != null)
+			{
+				password = value.toCharArray();
+			}
 		}
 	}
 

--- a/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttOutboundTransport.java
+++ b/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttOutboundTransport.java
@@ -129,6 +129,7 @@ public class MqttOutboundTransport extends OutboundTransportBase implements GeoE
 			options.setPassword(password);
 		}
 
+		if (ssl)
 		{
 			// Support TLS only (1.0-1.2) as even SSL 3.0 has well known exploits
 			java.util.Properties sslProperties = new java.util.Properties();

--- a/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport.properties
+++ b/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport.properties
@@ -3,6 +3,8 @@ TRANSPORT_IN_LBL=MQTT Inbound Transport
 TRANSPORT_IN_DESC=This is an MQTT inbound transport.
 TRANSPORT_IN_HOST_LBL=Host
 TRANSPORT_IN_HOST_DESC=Host URL of the connection to the MQTT broker, with optional scheme (tcp or ssl, default tcp) and port (default 1883, or 8883 for ssl).
+TRANSPORT_IN_QOS_LBL=QOS Level
+TRANSPORT_IN_QOS_DESC=Quality of Service level requested for subscription (0=at most once, 1=at least once, 2=exactly once)
 TRANSPORT_IN_TOPIC_LBL=Topic
 TRANSPORT_IN_TOPIC_DESC=Topic of the connection to the MQTT broker.
 TRANSPORT_IN_USERNAME_LBL=User name
@@ -15,12 +17,21 @@ TRANSPORT_OUT_LBL=MQTT Outbound Transport
 TRANSPORT_OUT_DESC=This is an MQTT outbound transport.
 TRANSPORT_OUT_HOST_LBL=Host
 TRANSPORT_OUT_HOST_DESC=Host URL of the connection to the MQTT broker, with optional scheme (tcp or ssl, default tcp) and port (default 1883, or 8883 for ssl).
+TRANSPORT_OUT_QOS_LBL=QOS Level
+TRANSPORT_OUT_QOS_DESC=Quality of Service level specified for delivery (0=at most once, 1=at least once, 2=exactly once)
+TRANSPORT_OUT_RETAIN_MESSAGE_LBL=Retain message
+TRANSPORT_OUT_RETAIN_MESSAGE_DESC=Instruct broker to retain last message sent on each distinct topic
 TRANSPORT_OUT_TOPIC_LBL=Topic
 TRANSPORT_OUT_TOPIC_DESC=Topic of the connection to the MQTT broker.
 TRANSPORT_OUT_USERNAME_LBL=User name
 TRANSPORT_OUT_USERNAME_DESC=Name of the user for the connection to the MQTT broker.
 TRANSPORT_OUT_PASSWORD_LBL=Password
 TRANSPORT_OUT_PASSWORD_DESC=Password for the connection to the MQTT broker.
+
+# Transport QOS option labels
+TRANSPORT_COMMON_QOS_0_LBL=0 (at most once)
+TRANSPORT_COMMON_QOS_1_LBL=1 (at least once)
+TRANSPORT_COMMON_QOS_2_LBL=2 (exactly once)
 
 # Log Messages
 CONNECTION_LOST=Connection lost: {0}

--- a/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport.properties
+++ b/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport.properties
@@ -2,9 +2,7 @@
 TRANSPORT_IN_LBL=MQTT Inbound Transport
 TRANSPORT_IN_DESC=This is an MQTT inbound transport.
 TRANSPORT_IN_HOST_LBL=Host
-TRANSPORT_IN_HOST_DESC=Host URL of the TCP connection to the MQTT broker.
-TRANSPORT_IN_PORT_LBL=Port
-TRANSPORT_IN_PORT_DESC=Port of the TCP connection to the MQTT broker.
+TRANSPORT_IN_HOST_DESC=Host URL of the connection to the MQTT broker, with optional scheme (tcp or ssl, default tcp) and port (default 1883, or 8883 for ssl).
 TRANSPORT_IN_TOPIC_LBL=Topic
 TRANSPORT_IN_TOPIC_DESC=Topic of the connection to the MQTT broker.
 
@@ -12,9 +10,7 @@ TRANSPORT_IN_TOPIC_DESC=Topic of the connection to the MQTT broker.
 TRANSPORT_OUT_LBL=MQTT Outbound Transport
 TRANSPORT_OUT_DESC=This is an MQTT outbound transport.b
 TRANSPORT_OUT_HOST_LBL=Host
-TRANSPORT_OUT_HOST_DESC=Host URL of the TCP connection to the MQTT broker.
-TRANSPORT_OUT_PORT_LBL=Port
-TRANSPORT_OUT_PORT_DESC=Port of the TCP connection to the MQTT broker.
+TRANSPORT_OUT_HOST_DESC=Host URL of the connection to the MQTT broker, with optional scheme (tcp or ssl, default tcp) and port (default 1883, or 8883 for ssl).
 TRANSPORT_OUT_TOPIC_LBL=Topic
 TRANSPORT_OUT_TOPIC_DESC=Topic of the connection to the MQTT broker.
 

--- a/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport_en_US.properties
+++ b/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport_en_US.properties
@@ -3,6 +3,8 @@ TRANSPORT_IN_LBL=MQTT Inbound Transport
 TRANSPORT_IN_DESC=This is an MQTT inbound transport.
 TRANSPORT_IN_HOST_LBL=Host
 TRANSPORT_IN_HOST_DESC=Host URL of the connection to the MQTT broker, with optional scheme (tcp or ssl, default tcp) and port (default 1883, or 8883 for ssl).
+TRANSPORT_IN_QOS_LBL=QOS Level
+TRANSPORT_IN_QOS_DESC=Quality of Service level requested for subscription (0=at most once, 1=at least once, 2=exactly once)
 TRANSPORT_IN_TOPIC_LBL=Topic
 TRANSPORT_IN_TOPIC_DESC=Topic of the connection to the MQTT broker.
 TRANSPORT_IN_USERNAME_LBL=User name
@@ -15,12 +17,21 @@ TRANSPORT_OUT_LBL=MQTT Outbound Transport
 TRANSPORT_OUT_DESC=This is an MQTT outbound transport.
 TRANSPORT_OUT_HOST_LBL=Host
 TRANSPORT_OUT_HOST_DESC=Host URL of the connection to the MQTT broker, with optional scheme (tcp or ssl, default tcp) and port (default 1883, or 8883 for ssl).
+TRANSPORT_OUT_QOS_LBL=QOS Level
+TRANSPORT_OUT_QOS_DESC=Quality of Service level specified for delivery (0=at most once, 1=at least once, 2=exactly once)
+TRANSPORT_OUT_RETAIN_MESSAGE_LBL=Retain message
+TRANSPORT_OUT_RETAIN_MESSAGE_DESC=Instruct broker to retain last message sent on each distinct topic
 TRANSPORT_OUT_TOPIC_LBL=Topic
 TRANSPORT_OUT_TOPIC_DESC=Topic of the connection to the MQTT broker.
 TRANSPORT_OUT_USERNAME_LBL=User name
 TRANSPORT_OUT_USERNAME_DESC=Name of the user for the connection to the MQTT broker.
 TRANSPORT_OUT_PASSWORD_LBL=Password
 TRANSPORT_OUT_PASSWORD_DESC=Password for the connection to the MQTT broker.
+
+# Transport QOS option labels
+TRANSPORT_COMMON_QOS_0_LBL=0 (at most once)
+TRANSPORT_COMMON_QOS_1_LBL=1 (at least once)
+TRANSPORT_COMMON_QOS_2_LBL=2 (exactly once)
 
 # Log Messages
 CONNECTION_LOST=Connection lost: {0}

--- a/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport_en_US.properties
+++ b/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport_en_US.properties
@@ -2,9 +2,7 @@
 TRANSPORT_IN_LBL=MQTT Inbound Transport
 TRANSPORT_IN_DESC=This is an MQTT inbound transport.
 TRANSPORT_IN_HOST_LBL=Host
-TRANSPORT_IN_HOST_DESC=Host URL of the TCP connection to the MQTT broker.
-TRANSPORT_IN_PORT_LBL=Port
-TRANSPORT_IN_PORT_DESC=Port of the TCP connection to the MQTT broker.
+TRANSPORT_IN_HOST_DESC=Host URL of the connection to the MQTT broker, with optional scheme (tcp or ssl, default tcp) and port (default 1883, or 8883 for ssl).
 TRANSPORT_IN_TOPIC_LBL=Topic
 TRANSPORT_IN_TOPIC_DESC=Topic of the connection to the MQTT broker.
 
@@ -12,9 +10,7 @@ TRANSPORT_IN_TOPIC_DESC=Topic of the connection to the MQTT broker.
 TRANSPORT_OUT_LBL=MQTT Outbound Transport
 TRANSPORT_OUT_DESC=This is an MQTT outbound transport.b
 TRANSPORT_OUT_HOST_LBL=Host
-TRANSPORT_OUT_HOST_DESC=Host URL of the TCP connection to the MQTT broker.
-TRANSPORT_OUT_PORT_LBL=Port
-TRANSPORT_OUT_PORT_DESC=Port of the TCP connection to the MQTT broker.
+TRANSPORT_OUT_HOST_DESC=Host URL of the connection to the MQTT broker, with optional scheme (tcp or ssl, default tcp) and port (default 1883, or 8883 for ssl).
 TRANSPORT_OUT_TOPIC_LBL=Topic
 TRANSPORT_OUT_TOPIC_DESC=Topic of the connection to the MQTT broker.
 

--- a/mqtt-transport/src/main/resources/mqtt-inbound-transport-definition.xml
+++ b/mqtt-transport/src/main/resources/mqtt-inbound-transport-definition.xml
@@ -8,12 +8,8 @@
 		<propertyDefinition propertyName="host"
 			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_HOST_LBL}"
 			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_HOST_DESC}"
-			propertyType="String" defaultValue="test.mosquitto.org" mandatory="true"
+			propertyType="String" defaultValue="tcp://iot.eclipse.org:1883" mandatory="true"
 			readOnly="false" />
-		<propertyDefinition propertyName="port"
-			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_PORT_LBL}"
-			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_PORT_DESC}"
-			propertyType="Integer" defaultValue="1883" mandatory="true" readOnly="false" />
 		<propertyDefinition propertyName="topic"
 			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_TOPIC_LBL}"
 			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_TOPIC_DESC}"

--- a/mqtt-transport/src/main/resources/mqtt-inbound-transport-definition.xml
+++ b/mqtt-transport/src/main/resources/mqtt-inbound-transport-definition.xml
@@ -10,6 +10,17 @@
 			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_HOST_DESC}"
 			propertyType="String" defaultValue="tcp://iot.eclipse.org:1883" mandatory="true"
 			readOnly="false" />
+		<propertyDefinition propertyName="qos"
+			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_QOS_LBL}"
+			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_QOS_DESC}"
+			propertyType="String" defaultValue="0" mandatory="true"
+			readOnly="false">
+			<allowedValues>
+				<value label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_COMMON_QOS_0_LBL}">0</value>
+				<value label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_COMMON_QOS_1_LBL}">1</value>
+				<value label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_COMMON_QOS_2_LBL}">2</value>
+			</allowedValues>
+		</propertyDefinition>
 		<propertyDefinition propertyName="topic"
 			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_TOPIC_LBL}"
 			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_TOPIC_DESC}"

--- a/mqtt-transport/src/main/resources/mqtt-outbound-transport-definition.xml
+++ b/mqtt-transport/src/main/resources/mqtt-outbound-transport-definition.xml
@@ -8,12 +8,8 @@
 		<propertyDefinition propertyName="host"
 			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_HOST_LBL}"
 			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_HOST_DESC}"
-			propertyType="String" defaultValue="test.mosquitto.org" mandatory="true"
+			propertyType="String" defaultValue="tcp://iot.eclipse.org:1883" mandatory="true"
 			readOnly="false" />
-		<propertyDefinition propertyName="port"
-			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_PORT_LBL}"
-			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_PORT_DESC}"
-			propertyType="Integer" defaultValue="1883" mandatory="true" readOnly="false" />
 		<propertyDefinition propertyName="topic"
 			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_TOPIC_LBL}"
 			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_TOPIC_DESC}"

--- a/mqtt-transport/src/main/resources/mqtt-outbound-transport-definition.xml
+++ b/mqtt-transport/src/main/resources/mqtt-outbound-transport-definition.xml
@@ -10,6 +10,22 @@
 			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_HOST_DESC}"
 			propertyType="String" defaultValue="tcp://iot.eclipse.org:1883" mandatory="true"
 			readOnly="false" />
+		<propertyDefinition propertyName="qos"
+			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_QOS_LBL}"
+			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_QOS_DESC}"
+			propertyType="String" defaultValue="0" mandatory="true"
+			readOnly="false">
+			<allowedValues>
+				<value label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_COMMON_QOS_0_LBL}">0</value>
+				<value label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_COMMON_QOS_1_LBL}">1</value>
+				<value label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_COMMON_QOS_2_LBL}">2</value>
+			</allowedValues>
+		</propertyDefinition>
+		<propertyDefinition propertyName="retain"
+			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_RETAIN_LBL}"
+			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_RETAIN_DESC}"
+			propertyType="Boolean" defaultValue="false" mandatory="true"
+			readOnly="false" />
 		<propertyDefinition propertyName="topic"
 			label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_TOPIC_LBL}"
 			description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_OUT_TOPIC_DESC}"


### PR DESCRIPTION
Add support in the host property for optional scheme via tcp:// or ssl:// prefix and port via a :12345 suffix, with scheme defaulting to tcp:// and port defaulting to 1883 for TCP / 8883 for SSL. Remove port number property which becomes redundant with this change. (Could have added a boolean property for SSL instead, but this way makes it easier to apply the correct default port.)