### PR TITLE
Update Paho and Bundle Plugin dependencies to latest

### DIFF
--- a/mqtt-transport/pom.xml
+++ b/mqtt-transport/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>org.eclipse.paho</groupId>
       <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-      <version>1.2.2</version>
+      <version>1.2.5</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <url>http://www.esri.com</url>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.bundle.plugin.version>4.0.0</maven.bundle.plugin.version>
+    <maven.bundle.plugin.version>4.2.1</maven.bundle.plugin.version>
     <junit.version>4.8.1</junit.version>
     <project.release>2</project.release>
   </properties>


### PR DESCRIPTION
A mini PR, tracking maintenance / bugfixes in Paho, to 1.2.5 from current reference 1.2.2. Also updated the bundle plugin to the latest 4.2.1, which has worked well for me in other GeoEvent components but shouldn't be a major change from current 4.0.0.