### PR TITLE
MQTT outbound connector doesn't use connection properties

### DIFF
--- a/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttTransportBase.java
+++ b/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttTransportBase.java
@@ -42,6 +42,8 @@ public abstract class MqttTransportBase extends TransportBase implements MqttCal
   public void afterPropertiesSet()
   {
     super.afterPropertiesSet();
+    // disconnect the transport before applying configuration changes
+    disconnect();
     // time to read transport configuration
     readConfig();
   }
@@ -274,8 +276,6 @@ public abstract class MqttTransportBase extends TransportBase implements MqttCal
 
   private void startTransport()
   {
-    if (mqttClientManager == null)
-      mqttClientManager = new MqttClientManager(config, LOGGER);
     startExecutor();
   }
 
@@ -287,6 +287,8 @@ public abstract class MqttTransportBase extends TransportBase implements MqttCal
 
   private void connect() throws Exception
   {
+    if (mqttClientManager == null)
+      mqttClientManager = new MqttClientManager(config, LOGGER);
     if (!mqttClientManager.isConnected()) {
       switch(getType()) {
         case INBOUND:
@@ -302,7 +304,10 @@ public abstract class MqttTransportBase extends TransportBase implements MqttCal
   private void disconnect()
   {
     if (mqttClientManager != null)
+    {
       mqttClientManager.disconnect();
+      mqttClientManager = null;
+    }
   }
 
   private void startExecutor() {

--- a/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttTransportBase.java
+++ b/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttTransportBase.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
 
 public abstract class MqttTransportBase extends TransportBase implements MqttCallback, Runnable
 {
-  protected static final BundleLogger LOGGER = BundleLoggerFactory.getLogger(MqttTransportBase.class.getName(), "com.esri.ges.framework.transport.transport-api");
+  protected static final BundleLogger LOGGER = BundleLoggerFactory.getLogger(MqttTransportBase.class.getName(), "com.esri.geoevent.transport.mqtt-transport");
   private MqttTransportConfig config;
   private MqttClientManager mqttClientManager;
   private ScheduledExecutorService executor;


### PR DESCRIPTION
See [#3814](https://devtopia.esri.com/WebGIS/arcgis-geoevent/issues/3814) for more details.

[x] Address an issue reported in verification https://devtopia.esri.com/WebGIS/arcgis-geoevent/issues/3814#issuecomment-3812792
[x] Improve MQTT transport reconnect logic
[x] Connector release version is not changed as requested https://devtopia.esri.com/WebGIS/arcgis-geoevent/issues/3814#issuecomment-3813826

GeoEvent build is available for verification at https://ps0016064.esri.com:6143/geoevent/manager

![Screenshot 2022-11-22 at 9 58 36 AM](https://user-images.githubusercontent.com/4493392/203387322-e39a5302-e6c5-41e7-a87e-4d0fe4d21aca.png)


![MQTT connection error](https://user-images.githubusercontent.com/4493392/203387029-b4137f06-2fb0-47b1-bce5-3664da692b0a.PNG)

![MQTT Release version 2](https://user-images.githubusercontent.com/4493392/203387059-eb6907bf-d2ce-4eb2-8a2b-949f8d74afc8.PNG)
