### PR TITLE
Gallery Item Integration - Publish latest MQTT to GeoEvent Gallery

### DIFF
--- a/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport.properties
+++ b/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport.properties
@@ -1,5 +1,5 @@
 # Inbound Transport Definition
-TRANSPORT_IN_LBL=MQTT Inbound Transport
+TRANSPORT_IN_LBL=MQTT
 TRANSPORT_IN_DESC=This inbound transport connects to an MQTT broker and receives message bytes on a specified topic.
 TRANSPORT_IN_HOST_LBL=Host
 TRANSPORT_IN_HOST_DESC=Host URL of the connection to the MQTT broker, with optional scheme (tcp or ssl, default tcp) and port (default 1883, or 8883 for ssl).
@@ -13,7 +13,7 @@ TRANSPORT_IN_PASSWORD_LBL=Password
 TRANSPORT_IN_PASSWORD_DESC=Password for the connection to the MQTT broker.
 
 # Outbound Transport Definition
-TRANSPORT_OUT_LBL=MQTT Outbound Transport
+TRANSPORT_OUT_LBL=MQTT
 TRANSPORT_OUT_DESC=This outbound transport connects to an MQTT broker and sends message bytes to a specified topic.
 TRANSPORT_OUT_HOST_LBL=Host
 TRANSPORT_OUT_HOST_DESC=Host URL of the connection to the MQTT broker, with optional scheme (tcp or ssl, default tcp) and port (default 1883, or 8883 for ssl).

--- a/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport_en_US.properties
+++ b/mqtt-transport/src/main/resources/com/esri/geoevent/transport/mqtt-transport_en_US.properties
@@ -1,5 +1,5 @@
 # Inbound Transport Definition
-TRANSPORT_IN_LBL=MQTT Inbound Transport
+TRANSPORT_IN_LBL=MQTT
 TRANSPORT_IN_DESC=This inbound transport connects to an MQTT broker and receives message bytes on a specified topic.
 TRANSPORT_IN_HOST_LBL=Host
 TRANSPORT_IN_HOST_DESC=Host URL of the connection to the MQTT broker, with optional scheme (tcp or ssl, default tcp) and port (default 1883, or 8883 for ssl).
@@ -13,7 +13,7 @@ TRANSPORT_IN_PASSWORD_LBL=Password
 TRANSPORT_IN_PASSWORD_DESC=Password for the connection to the MQTT broker.
 
 # Outbound Transport Definition
-TRANSPORT_OUT_LBL=MQTT Outbound Transport
+TRANSPORT_OUT_LBL=MQTT
 TRANSPORT_OUT_DESC=This outbound transport connects to an MQTT broker and sends message bytes to a specified topic.
 TRANSPORT_OUT_HOST_LBL=Host
 TRANSPORT_OUT_HOST_DESC=Host URL of the connection to the MQTT broker, with optional scheme (tcp or ssl, default tcp) and port (default 1883, or 8883 for ssl).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.bundle.plugin.version>4.0.0</maven.bundle.plugin.version>
     <junit.version>4.13.1</junit.version>
-    <project.release>2</project.release>
+    <project.release>3</project.release>
   </properties>
   <modules>
     <module>mqtt-transport</module>


### PR DESCRIPTION
See [#3958](https://devtopia.esri.com/WebGIS/arcgis-geoevent/issues/3958#issue-1421983) for more details.

[x] Connector release number is changed to 3.
![Screenshot 2023-03-08 at 2 02 25 PM](https://user-images.githubusercontent.com/4493392/223862189-484cc5be-e040-49a9-90e2-8aeda7c9fa14.png)

[x] Label for Inbound transport is changed to 'MQTT'
![Screenshot 2023-03-08 at 2 01 37 PM](https://user-images.githubusercontent.com/4493392/223862332-7500835e-882b-4697-b5fe-3167c7e02488.png)

[x] Label for Outbound transport is changed to 'MQTT'
![Screenshot 2023-03-08 at 2 01 06 PM](https://user-images.githubusercontent.com/4493392/223862342-9c7a27d6-eca3-475e-8ddb-625b0bb0de16.png)

An updated jar is available at \\esri.com\psdata\Ent_Sol\GeoEvent\TestData\Devtopia\arcgis-geoevent\Issue3958

GeoEvent instance to test is available at https://ps0017015.esri.com:6143/geoevent/manager

