### PR TITLE
i have added 4 properties for mqttclient inbound (clientId, cleanSession, keepAliveInterval and autoReconnect)

### DIFF
--- a/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttClientManager.java
+++ b/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttClientManager.java
@@ -61,6 +61,7 @@ public class MqttClientManager
 
     mqttClient = createMqttClient(callback);
     mqttClient.connect(config.getConnectOptions());
+    LOGGER.info("mqttClient connected clientId=" + mqttClient.getClientId());
   }
 
   public boolean isConnected()
@@ -135,7 +136,8 @@ public class MqttClientManager
   {
     LOGGER.trace("Creating new MQTT client...");
     LOGGER.debug("Creating MQTT Broker client at URL {0}", config.getUrl());
-    MqttClient mqttClient = new MqttClient(config.getUrl(), MqttClient.generateClientId(), new MemoryPersistence());
+    /* MqttClient mqttClient = new MqttClient(config.getUrl(), MqttClient.generateClientId(), new MemoryPersistence()); */
+    MqttClient mqttClient = new MqttClient(config.getUrl(), config.getClientId(), new MemoryPersistence());
     if (callback != null)
     {
       LOGGER.trace("Setting MQTT callback to receive messages");

--- a/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttTransportBase.java
+++ b/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttTransportBase.java
@@ -239,7 +239,7 @@ public abstract class MqttTransportBase extends TransportBase implements MqttCal
     }
 
     // qos is an integer from the set [0, 1, or 2]
-    int qos = 0;
+    int qos = 1;
     if (hasProperty("qos"))
     {
       String qosValue = getPropertyValueAsString("qos", errors);
@@ -257,6 +257,7 @@ public abstract class MqttTransportBase extends TransportBase implements MqttCal
         }
       }
     }
+    LOGGER.info("Property value qos = " + qos);
 
     // retain is a boolean value
     boolean isRetain = false;
@@ -271,7 +272,69 @@ public abstract class MqttTransportBase extends TransportBase implements MqttCal
         isRetain = Boolean.parseBoolean(retainValue);
       }
     }
-    config = new MqttTransportConfig(host, port, (topic == null) ? "": topic, isUseSSL, username, password, qos, isRetain, errors);
+
+    //clientId is a string value
+    String clientId = "";
+    if (hasProperty("clientId")) {
+      clientId = getPropertyValueAsString("clientId", errors).trim();
+    }
+    if (StringUtils.isEmpty(clientId))
+    {
+      // mandatory property value is null or empty -> report this error
+      errors.add("Property value clientId cannot be NULL or EMPTY.");
+    }
+    LOGGER.info("Property value clientId = " + clientId);
+
+    // cleanSession is a boolean value
+    boolean cleanSession = false;
+    if (hasProperty("cleanSession"))
+    {
+      String cleanSessionValue = getPropertyValueAsString("cleanSession", errors);
+      if (StringUtils.isEmpty(cleanSessionValue))
+      {
+        // mandatory property value is null or empty -> report this error
+        errors.add("Property value cleanSession cannot be NULL or EMPTY.");
+      } else {
+        cleanSession = Boolean.parseBoolean(cleanSessionValue);
+      }
+    }
+    LOGGER.info("Property value cleanSession = " + cleanSession);
+
+    // keepAliveInterval is an integer
+    int keepAliveInterval = 60;
+    if (hasProperty("keepAliveInterval")) {
+      String keepAliveIntervalValue = getPropertyValueAsString("keepAliveInterval", errors);
+      if (StringUtils.isEmpty(keepAliveIntervalValue)) {
+        // mandatory property value is null or empty -> report this error
+        errors.add("Property value keepAliveInterval cannot be NULL or EMPTY.");
+      } else {
+        try {
+          keepAliveInterval = Integer.parseInt(keepAliveIntervalValue);
+          if (keepAliveInterval < 0)
+            errors.add("Property value keepAliveInterval must be >= 0.");
+        } catch (NumberFormatException error) {
+          errors.add("Property value keepAliveInterval is not valid.");
+        }
+      }
+    }
+    LOGGER.info("Property value keepAliveInterval = " + keepAliveInterval);
+
+    // autoReconnect is a boolean value
+    boolean autoReconnect = true;
+    if (hasProperty("autoReconnect"))
+    {
+      String autoReconnectValue = getPropertyValueAsString("autoReconnect", errors);
+      if (StringUtils.isEmpty(autoReconnectValue))
+      {
+        // mandatory property value is null or empty -> report this error
+        errors.add("Property value autoReconnect cannot be NULL or EMPTY.");
+      } else {
+        autoReconnect = Boolean.parseBoolean(autoReconnectValue);
+      }
+    }
+    LOGGER.info("Property value autoReconnect = " + autoReconnect);
+
+    config = new MqttTransportConfig(host, port, (topic == null) ? "": topic, isUseSSL, username, password, qos, isRetain, errors, clientId, cleanSession, keepAliveInterval, autoReconnect);
   }
 
   private void startTransport()

--- a/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttTransportConfig.java
+++ b/mqtt-transport/src/main/java/com/esri/geoevent/transport/mqtt/MqttTransportConfig.java
@@ -19,6 +19,10 @@ public class MqttTransportConfig
   private final String url;
   private final MqttConnectOptions connectOptions;
   private final List<String> errors;
+  private final String clientId;
+  private final boolean cleanSession;
+  private final int keepAliveInterval;
+  private final boolean autoReconnect;
 
   public MqttTransportConfig(
       String host,
@@ -29,7 +33,11 @@ public class MqttTransportConfig
       String password,
       int qos,
       boolean isRetain,
-      List<String> errors)
+      List<String> errors,
+      String clientId,
+      boolean cleanSession,
+      int keepAliveInterval,
+      boolean autoReconnect)
   {
     this.host = host;
     this.port = port;
@@ -40,6 +48,10 @@ public class MqttTransportConfig
     this.password = password;
     this.qos = qos;
     this.isRetain = isRetain;
+    this.clientId = clientId;
+    this.cleanSession = cleanSession;
+    this.keepAliveInterval = keepAliveInterval;
+    this.autoReconnect = autoReconnect;
 
     // initialize Mqtt connect options
     this.connectOptions = new MqttConnectOptions();
@@ -65,7 +77,10 @@ public class MqttTransportConfig
       // initialize url for non-ssl connection
       this.url = "tcp://" + host + ":" + port;
     }
-    connectOptions.setCleanSession(true);
+
+    connectOptions.setCleanSession(cleanSession);
+    connectOptions.setKeepAliveInterval(keepAliveInterval);
+    connectOptions.setAutomaticReconnect(autoReconnect);
 
     this.errors = errors;
   }
@@ -114,9 +129,13 @@ public class MqttTransportConfig
     return errors;
   }
 
+  public String getClientId() {
+    return clientId;
+  }
+
   @Override
   public String toString()
   {
-    return "port=" + port + ", host=" + host + ", ssl=" + isUseSSL + ", topic=" + topic + ", qos=" + qos + ", username=" + username + ", password=" + password + ", retain=" + isRetain;
+    return "port=" + port + ", host=" + host + ", ssl=" + isUseSSL + ", topic=" + topic + ", qos=" + qos + ", username=" + username + ", password=" + password + ", retain=" + isRetain + ", clientId=" + clientId + ", cleanSession=" + cleanSession + ", keepAliveInterval=" + keepAliveInterval + ", autoReconnect=" + autoReconnect;
   }
 }

--- a/mqtt-transport/src/main/resources/mqtt-inbound-transport-definition.xml
+++ b/mqtt-transport/src/main/resources/mqtt-inbound-transport-definition.xml
@@ -19,5 +19,14 @@
       description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_USERNAME_DESC}" propertyType="String" defaultValue="" mandatory="false" readOnly="false" />
     <propertyDefinition propertyName="password" label="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_PASSWORD_LBL}"
       description="${com.esri.geoevent.transport.mqtt-transport.TRANSPORT_IN_PASSWORD_DESC}" propertyType="Password" defaultValue="" mandatory="false" readOnly="false" />
+
+    <propertyDefinition propertyName="clientId" label="Client ID" description="Client ID"
+                        propertyType="String" defaultValue="" mandatory="true" readOnly="false" />
+    <propertyDefinition propertyName="cleanSession" label="Clean Session" description="Clean Session"
+                        propertyType="Boolean" defaultValue="false" mandatory="true" readOnly="false" />
+    <propertyDefinition propertyName="keepAliveInterval" label="Keep Alive Interval (in seconds)" description="Keep Alive Interval (in seconds)"
+                        propertyType="Integer" defaultValue="60" mandatory="true" readOnly="false" />
+    <propertyDefinition propertyName="autoReconnect" label="Auto Reconnect" description="Auto Reconnect"
+                        propertyType="Boolean" defaultValue="true" mandatory="true" readOnly="false" />
   </propertyDefinitions>
 </transport>


### PR DESCRIPTION
Hello Esri team,

I came across this as I modified it slightly to include 4 more properties to fit my ArcGIS GeoEvent Server project.

1. clientId for specify a client id 

2. cleanSession is for setCleanSession(boolean cleanSession)
Sets whether the client and server should remember state across restarts and reconnects.

3. keepAliveInterval is for setKeepAliveInterval(int keepAliveInterval)
Sets the "keep alive" interval.

4. autoReconnect is for setAutomaticReconnect(boolean automaticReconnect)
Sets whether the client will automatically attempt to reconnect to the server if the connection is lost.